### PR TITLE
Name attribute fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freesewing/plugin-dimension",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A freesewing plugin to add dimensions to your (paperless) pattern",
   "author": "Joost De Cock <joost@decock.org> (https://github.com/joostdecock)",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default {
   hooks: {
     preRender: function(next) {
       this.defs += markers;
-      this.attributes.add("freesewing:plugin-cutonfold", version);
+      this.attributes.add("freesewing:plugin-dimension", version);
       next();
     }
   },


### PR DESCRIPTION
The name of the plugin in the SVG attributes was set to `plugin-cutonfold` which is the name of a different plugin. Changed it to `plugin-dimension` and updated the version number to 0.5.2.